### PR TITLE
use 'Conda' easyblock + empty version for dummy toolchain + some minor enhancements

### DIFF
--- a/easybuild/easyconfigs/g/gencore_variant_detection/gencore_variant_detection-1.0.eb
+++ b/easybuild/easyconfigs/g/gencore_variant_detection/gencore_variant_detection-1.0.eb
@@ -10,7 +10,7 @@
 # http://apps.fz-juelich.de/unite/
 ##
 
-easyblock = 'EB_Conda'
+easyblock = 'Conda'
 
 name = "gencore_variant_detection"
 version = "1.0"
@@ -19,15 +19,12 @@ variant = "Linux-x86_64"
 homepage = "https://nyuad-cgsb.github.io/variant_detection/public/index.html"
 description = """ This is a bundled install of many software packages for doing variant detection analysis. """
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 builddependencies = [('Anaconda3', '4.0.0')]
 
-#Use one of the following  - either an environment.yml file or a remote environment definition
-#sources = ["environment.yml"]
-#environment_file = sources[0]
-
-#remote_environment = "nyuad-cgsb/gencore_variant_detection_1.0"
+# Use one of the following  - either an environment.yml file or a remote environment definition
+#environment_file = '/path/to/conda-environment.yml'
 remote_environment = "nyuad-cgsb/%(name)s_%(version)s"
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/p/perl_app_cpanminus/perl-app-cpanminus-1.7039.eb
+++ b/easybuild/easyconfigs/p/perl_app_cpanminus/perl-app-cpanminus-1.7039.eb
@@ -10,13 +10,13 @@
 # http://apps.fz-juelich.de/unite/
 ##
 
-easyblock = 'EB_Conda'
+easyblock = 'Conda'
 
 name = "perl-app-cpanminus"
 version = "1.7039"
 variant = "Linux-x86_64"
 
-homepage = "http://search.cpan.org/~miyagawa/Menlo-1.9003/script/cpanm-menlo"
+homepage = 'https://github.com/miyagawa/cpanminus'
 description = """ cpanm - get, unpack build and install modules from CPAN """
 
 toolchain = {'name': 'dummy', 'version': ''}


### PR DESCRIPTION
for https://github.com/hpcugent/easybuild-easyconfigs/pull/3337

@jerowe two of these changes are critical:

* using `Conda` as easyblock (`EB_Conda` does not exist anymore since `Conda` is a generic easyblock now)
* using empty string (`''`) in the `toolchain` spec, otherwise the `Anaconda` dependency does not get loaded during installation, resulting in `conda` command not being available

However, there's still a problem in https://github.com/hpcugent/easybuild-easyblocks/pull/950:

```
== 2016-11-13 19:05:56,808 run.py:433 DEBUG cmd " conda env create nyuad-cgsb/gencore_variant_detection_1.0 -p /user/home/gent/vsc400/vsc40023/eb_phanpyscratch/SL6/sandybridge/software/gencore_variant_detection/1.0" exited with exitcode 2 and output:
usage: conda-env [-h] {attach,create,export,list,remove,upload,update} ...
conda-env: error: unrecognized arguments: -p /user/home/gent/vsc400/vsc40023/eb_phanpyscratch/SL6/sandybridge/software/gencore_variant_detection/1.0
```

Any idea what's wrong there?